### PR TITLE
Add vann properties

### DIFF
--- a/FFK.ttl
+++ b/FFK.ttl
@@ -2,6 +2,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
 
 <> a skos:ConceptScheme ;
   skos:prefLabel "Forschungsfeldklassifikation"@de ,
@@ -16,6 +17,8 @@
   dct:creator <https://orcid.org/0000-0003-4891-762X> ;
   dct:creator <https://orcid.org/0000-0001-9415-9263> ;
   dct:creator <https://orcid.org/0000-0002-2011-9645> ;
+  vann:preferredNamespaceUri "https://w3id.org/kdsf-ffk/" ;
+  vann:preferredNamespacePrefix "kdsf-ffk" ;
   dct:license <https://creativecommons.org/licenses/by-sa/4.0/> ;
   skos:hasTopConcept <ArbeitUndWirtschaft>, <ErdeUndKosmos>, <GlobalisierungUndNachhaltigkeit>, <Industrie>, <Informationstechnologie>, <Infrastruktur>, <KognitionUndWissen>, <Kultur>, <LebenUndWohlergehen>, <Materialien>, <MenschUndGesellschaft>, <NaturUndUmwelt>, <Technologie>, <Wissenschaft>, <KeinesDerGelistetenForschungsfelder>.
 


### PR DESCRIPTION
...for indicating namespace and preferred prefix for the concept scheme.  

Context: 
[VANN: A vocabulary for annotating vocabulary descriptions](https://vocab.org/vann/) is also used in the [Linked Open Vocabularies](https://lov.linkeddata.es/dataset/lov/) service and you also need it to set up a reconciliation endpoint for a vocabulary with SkoHub Reconcile (which I intend to do with this vocab for a demo). 